### PR TITLE
fix: command proceeds even with invalid MODBUS device address

### DIFF
--- a/src/rs485.c
+++ b/src/rs485.c
@@ -35,6 +35,7 @@ int rs485Set(int dev, u8 mode, u32 baud, u8 stopB, u8 parity, u8 add)
 	if (add < 1)
 	{
 		printf("Invalid MODBUS device address: [1, 255]!\n");
+		return ERROR;
 	}
 	settings.mbBaud = baud;
 	settings.mbType = mode;


### PR DESCRIPTION
I don't think this is intended behavior. I was able to set the address to 0. 

This raises another question. Is there a reason why we can't set it to 0?