### PR TITLE
Improved r2t fit

### DIFF
--- a/python/rtd/librtd/__init__.py
+++ b/python/rtd/librtd/__init__.py
@@ -41,3 +41,49 @@ def getRes(stack, channel):
         raise ValueError('Fail to communicate with the RTD card with message: \"' + str(e) + '\"')
     bus.close()
     return val[0]
+
+
+def get_poly5(stack: int, channel: int) -> float:
+    """
+    Convert RTD reading to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
+    This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
+    and low ranges, compared to the default linear fitting function baked into the Sequent RTD Data Acquisition
+    Stackable Card for Raspberry Pi.  The coefficients for this fit were developed in a project documented
+    in https://github.com/ewjax/max31865
+
+        temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
+
+    :param stack: 0-7, which hat to read
+    :param channel: 1-8, which RTD to read on indicated hat
+    :return: temperature, in celcius
+    """
+
+    # coeffs for 5th order fit
+    c5 = -2.10678E-11
+    c4 = 2.27311E-08
+    c3 = -8.20888E-06
+    c2 = 2.38589E-03
+    c1 = 2.24745E+00
+    c0 = -2.42522E+02
+
+    # get RTD resistance
+    res = getRes(stack, channel)
+
+    # do the math
+    #   Rearrange a bit to make it friendlier (less expensive) to calculate
+    #   temp_C = res ( res ( res ( res ( res * c5 + c4) + c3) + c2) + c1) + c0
+    temp_C = res * c5 + c4
+
+    temp_C *= res
+    temp_C += c3
+
+    temp_C *= res
+    temp_C += c2
+
+    temp_C *= res
+    temp_C += c1
+
+    temp_C *= res
+    temp_C += c0
+
+    return temp_C

--- a/src/rtd.c
+++ b/src/rtd.c
@@ -414,8 +414,15 @@ int doRtdReadR(int argc, char *argv[])
 
 /*
  * doRtdReadPoly5:
- *  Read temperature on one channel, using a 5th order polynomial fit
- *  of resistance to temperature
+ *
+ *  Read RTD resistance and convert it to Temperature, using 5th order polynomial fit of Temperature as a function of Resistance.
+ *  This fit provides much improved accuracy through the temperature range of [-200C, 660C], particularly near the high
+ *  and low ranges, compared to the default linear fitting function baked into the Sequent RTD Data Acquisition
+ *  Stackable Card for Raspberry Pi.  The coefficients for this fit were developed in a project documented
+ *  in https://github.com/ewjax/max31865
+ *
+ *      temp_C = (c5 * res^5) + (c4 * res^4) + (c3 * res^3) + (c2 * res^2) + (c1 * res) + c0
+ * 
  ******************************************************************************************
  */
 int doRtdReadPoly5(int argc, char *argv[])


### PR DESCRIPTION
The "read temperature" function baked into the hardware for the Sequent RTD hat works by reading the resistance of the RTD, then converting that resistance to temperature, using a linear fitting equation of temperature as a function of resistance. 

This fit is actually quite reasonable for the middle, most common range of the PT100 detector, roughly for temperatures in the range of [0, 100] degrees centigrade.  However, it does begin to degrade as the temperatures get much outside that range.  Here is a graph showing the raw (temperature, resistance) measured data for PT100 detectors, and the Sequent linear fit:

![image](https://github.com/SequentMicrosystems/rtd-rpi/assets/53411769/302e48a1-ad78-4474-9706-9f67e9c813ab)

It's not a bad fit.  It just begins to degrade at the high/low ranges.

To address this issue, a few years ago I had developed some improved polynomial fits, that give very good accuracy across the entire range of temperatures [-200C, 660C], in a project documented in https://github.com/ewjax/max31865.

This pull request adds the 5th order polynomial fits from that effort into the C and Python software source code.  It leaves the current "read temperature" functions intact, so there is no change to the default behavior, but adds an additional function to perform the 5th order polynomial fit of temperature vs resistance.  The polynomial fit could actually be used across the entire range of temperatures if desired, as the fit accuracy is quite good, showing a maximum error of 0.13 degC across the range [-200, 660], but I decided to leave it as an "extra" feature and not as a "replacement" feature.