### PR TITLE
fix for zip_safe install error on Raspberry Pi OS

### DIFF
--- a/python/rtd/setup.py
+++ b/python/rtd/setup.py
@@ -8,6 +8,7 @@ setuptools.setup(
     version="1.1.0",
     author="Sequent Microsystems",
     author_email="olcitu@gmail.com",
+    zip_safe=True,
     description="A set of functions to control Sequent Microsystems MEGA_RTD board",
 	license='MIT',
     url="https://www.sequentmicrosystems.com",


### PR DESCRIPTION
On a fresh Raspberry Pi OS install, executing the python librtd install command of

sudo python setup.py install

will generate an error complaining about "zip_safe" being set incorrectly.  Adding a line to setup.py corrects this problem and allows the library installation to succeed.